### PR TITLE
docs: clarify README usage heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An [Alfred workflow](https://www.alfredapp.com/workflows/) to clone git repos li
 
 Download the latest version from [Releases](https://github.com/almibarss/alfred-git-clone/releases) and double click the downloaded file to install it!!!
 
-## Usage
+## How to use
 
 > **Note**: Clipboard history must be enabled in order for us to scrape. Enable this via Alfred Preferences > Features > Clipboard History.
 


### PR DESCRIPTION
Change the README section title from "Usage" to "How to use" to make the
intent clearer and more user-friendly. This improves discoverability for
users scanning the documentation and aligns the heading with the
instructional content that follows (clipboard history note). No functional
code changes.