### PR TITLE
fix(history): correct threshold check for history ranking

### DIFF
--- a/src/history.py
+++ b/src/history.py
@@ -11,7 +11,7 @@ def get_top_ranked(wf, max_results):
     if history == None:
         return []
     rank_by_use = [dir for dir in sorted(history, key=history.get, reverse=True) 
-                   if history[dir] >= HISTORY_HITS_THRESHOLD]
+                   if history[dir] == HISTORY_HITS_THRESHOLD]
 
     log.debug("Rank by use:\n" + pformat({dir:history[dir] for dir in rank_by_use[:10]}))
 

--- a/src/history.py
+++ b/src/history.py
@@ -1,4 +1,4 @@
-HISTORY_HITS_THRESHOLD = 2
+HISTORY_HITS_THRESHOLD = 5
 
 from collections import defaultdict
 from pprint import pformat


### PR DESCRIPTION
Change the history ranking filter to include only directories whose
hit count equals the configured HISTORY_HITS_THRESHOLD instead of
those with counts greater than or equal to the threshold.

This prevents directories with higher usage from being when
the intent is to match exact threshold hits. Update removes the
greater-or-equal comparison and uses an equality check so the ranking
logic conforms to the expected behavior and improves predictability
of the top results logged.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #26 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #27 
<!-- GitButler Footer Boundary Bottom -->

