### PR TITLE
perf: increase hits threshold to 5

### DIFF
--- a/src/history.py
+++ b/src/history.py
@@ -1,4 +1,4 @@
-HISTORY_HITS_THRESHOLD = 2
+HISTORY_HITS_THRESHOLD = 5
 
 from collections import defaultdict
 from pprint import pformat


### PR DESCRIPTION
Raise HISTORY_HITS_THRESHOLD 2 to 5 to reduce noisy
or overly-frequent history entries being treated as important.
This change makes the system require more repeated hits before
promoting or surfacing history items, improving signal-to-noise
for features that rely on hit counts (e.g., suggestions,
prioritization).
Tests and behavior relying on the threshold should observe fewer
promotions for low-frequency items.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #26 
- <kbd>&nbsp;1&nbsp;</kbd> #27 👈 
<!-- GitButler Footer Boundary Bottom -->

